### PR TITLE
Bugfixes to RAR original code

### DIFF
--- a/include/PicoResponsiveAnalogRead/PicoResponsiveAnalogRead.hpp
+++ b/include/PicoResponsiveAnalogRead/PicoResponsiveAnalogRead.hpp
@@ -234,7 +234,7 @@ private:
   float activityThreshold = 4.0;
   bool edgeSnapEnable = true;
 
-  float smoothValue;
+  float smoothValue = 0.0;
   unsigned long lastActivityMS;
   float errorEMA = 0.0;
   bool sleeping = false;

--- a/include/PicoResponsiveAnalogRead/PicoResponsiveAnalogRead.hpp
+++ b/include/PicoResponsiveAnalogRead/PicoResponsiveAnalogRead.hpp
@@ -142,7 +142,7 @@ public:
     // add a small amount to snap so it'll tend to snap into a more accurate
     // position before sleeping starts.
     if (sleepEnable) {
-      snap *= 0.5 + 0.5;
+      snap = (snap*0.5) + 0.5;
     }
 
     // calculate the exponential moving average based on the snap


### PR DESCRIPTION
I made my own verison of this a while back, but the CMake/cmp version is much nicer. So I'm pushing the two bugfixes myself and @TomWhitwell have previously encountered with this:

* not initializing smoothValue can lead to issues downstream
* there's a piece of syntax that's just wrong, and had no effect - which is not what the original author intended.

Both of these bugs have existed for ages, and have been faithfully passed down between versions of RAR (which is a library I like and use a lot) - but I'm doing my best to submit PRs when I encounter them around the internet.